### PR TITLE
업데이트 시에만 실행되는 sideEffect 훅 추가

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,3 +6,4 @@ export { default as useMultiState } from "./src/hooks/useMultiState";
 export { default as useWindowResize } from "./src/hooks/useWindowResize";
 export { default as usePageNavigation } from "./src/hooks/usePageNavigation";
 export { default as useCheckbox } from "./src/hooks/useCheckBox";
+export { default as useUpdateEffect } from "./src/hooks/useUpdateEffect";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taeo-hooks",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taeo-hooks",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "react-router-dom": "^6.21.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taeo-hooks",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "taeo's custom hooks playgrounds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/hooks/useUpdateEffect.ts
+++ b/src/hooks/useUpdateEffect.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from "react";
+import type { DependencyList } from "react";
+
+/**
+ * 컴포넌트가 처음 마운트될 때가 아닌, 업데이트 시에만 실행되는 사용자 정의 React 훅입니다.
+ *
+ * @param callback - 컴포넌트 업데이트 시에 실행될 콜백 함수입니다.
+ * @param deps - 콜백을 실행할 조건으로 설정된 의존성 배열입니다.
+ */
+export default function useUpdateEffect(callback: () => void, deps: DependencyList) {
+  const ref = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (ref.current) {
+      callback();
+    } else {
+      console.log("첫 번째 마운트입니다. 업데이트가 아닙니다.");
+      ref.current = true;
+    }
+  }, [...deps]);
+}


### PR DESCRIPTION
### PR 타입


- [x] 기능 추가
- [x] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### PR 생성 날짜

- 2024/01/29 -> develop

### 반영 브랜치

- feature/side-effect-hooks -> develop

### PR 목적

- 생명주기를 다룰 때, 업데이트를 명시적으로 표현하지 않고 무수히 많은 `useEffect` 들이 있을 때, . 헷갈림을 유도한다.
- 따라서, 업데이트 시에만 발생하도록 하는 훅으로 명시적 표현할 필요가 있다고 판단되어서 만들게 되었다.

### PR 내용

- `useUpdateEffect` : 업데이트시에만 발생하는 훅


