### PR TITLE
로컬스토리지에 CRUD를 위한 훅 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taeo-hooks",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taeo-hooks",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "MIT",
       "dependencies": {
         "react-router-dom": "^6.21.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taeo-hooks",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "taeo's custom hooks playgrounds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,45 @@
+import React, { useCallback, useEffect, useState } from "react";
+
+const isServer = typeof window === "undefined";
+
+export default function useLocalStorage<T>(key: string, initialValue: T | (() => T), options = {}) {
+  const [storedValue, setStoredValue] = useState<T>(initialValue);
+
+  /** 로컬 스토리지 읽기 */
+  const read = () =>
+    useCallback((): T => {
+      // initialValue 가 함수인지 아닌지 여부 확인한다. true = 함수형일 경우 해당 함수를 호출한다. / false = 함수형이 아닐 경우 초깃값을 그대로 호출한다.
+      const initialValueToUse = initialValue instanceof Function ? initialValue() : initialValue;
+
+      // SSR에서 발생할 수 있는 오류 방지하기 위해 설정. window 객체가 존재하지 않을때, localStorage에 접근 하는 것을 방지
+      if (isServer) {
+        return initialValueToUse;
+      }
+
+      try {
+        const rawData = window.localStorage.getItem(key) as T;
+
+        if (!rawData) return initialValueToUse;
+
+        return rawData ? rawData : initialValueToUse;
+      } catch {
+        console.warn(`로컬 스토리지를 가져오는 것에 실패하였습니다. 키 : "${key}", 값 : error  `);
+        return initialValueToUse;
+      }
+    }, [initialValue, key]);
+
+  /** 로컬 스토리지 저장 */
+  const save = () => {};
+
+  /** 로컬 스토리지 수정 */
+  const update = () => {};
+
+  /** 로컬 스토리지 삭제 */
+  const remove = () => {};
+
+  useEffect(() => {
+    setStoredValue(read());
+  }, [key]);
+
+  return { read };
+}


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### PR 생성 날짜

- 2024/01/30

### 반영 브랜치

- feature/fetch-hooks -> develop

### PR 목적

- 개인이 쓰일 수 있는 다양한 정보들 예를 들어 토큰, 테마 등 다양한 값들을 보통 브라우저의 스토리지에 저장하여 사용하기도 한다.
- 예를 들어 로컬 스토리지나 쿠키 등을 이용할 수 있다.
- 그럴때 쉽게 함수형 컴포넌트에서 꺼내어 사용하기 편하도록 할 필요성을 느꼈다.
- 따라서, 로컬스토리지에서 CRUD가 편할 수 있는 훅을 만들었다. 
- 사실 따로 모듈을 만드는것이 유리할 수 있으나, 훅으로 사용하게 된다면 꽤나 저장해야할 요소가 클 수 도 있을거라 판단하였고
- 최대한 최적화를 하고자 하였다.

### PR 내용

- 읽기, 저장, 수정 등의 기능 구현