### PR TITLE
미디어 쿼리 추적하는 기능의 훅 추가

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,4 +9,3 @@ export { default as useCheckbox } from "./src/hooks/useCheckBox";
 export { default as useUpdateEffect } from "./src/hooks/useUpdateEffect";
 export { default as useOutSideClick } from "./src/hooks/useOutSideClick";
 export { default as useTimer } from "./src/hooks/useTimer";
-export { default as useMediaQuery } from "./src/hooks/useMediaQuery";

--- a/index.ts
+++ b/index.ts
@@ -9,3 +9,4 @@ export { default as useCheckbox } from "./src/hooks/useCheckBox";
 export { default as useUpdateEffect } from "./src/hooks/useUpdateEffect";
 export { default as useOutSideClick } from "./src/hooks/useOutSideClick";
 export { default as useTimer } from "./src/hooks/useTimer";
+export { default as useMediaQuery } from "./src/hooks/useMediaQuery";

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import useUpdateEffect from "./useUpdateEffect";
+
+/**
+ * 이 훅은 주어진 미디어 쿼리에 대한 상태를 관리하는 커스텀 훅입니다.
+ * @param {string} query - 사용할 미디어 쿼리, 문자열로 입력합니다.
+ * @returns {boolean} - 주어진 미디어 쿼리에 대한 매치 결과 (true 또는 false)를 반환합니다.
+ */
+export default function useMediaQuery(query: string): boolean {
+  const [media, setMedia] = useState<boolean>(() => {
+    const mediaQuery = window.matchMedia(query);
+    return mediaQuery.matches;
+  });
+
+  // 컴포넌트가 업데이트되었을 때 실행되는 useEffect
+  useUpdateEffect(() => {
+    // 주어진 미디어 쿼리에 대한 MediaQueryList 객체 생성
+    const mediaQuery = window.matchMedia(query);
+
+    // 미디어 쿼리 상태 변경 이벤트 핸들러
+    const handleMediaChage = (event: MediaQueryListEvent) => {
+      // 매치 결과를 상태에 반영
+      setMedia(event.matches);
+    };
+
+    // "Chnage" 이벤트 핸들러를 추가할 때는 함수 참조를 전달
+    mediaQuery.addEventListener("change", handleMediaChage);
+
+    // 초기 값 설정
+    setMedia(mediaQuery.matches);
+
+    // 컴포넌트가 언마운트되거나 미디어 쿼리 변경 시 "change" 이벤트 핸들러 제거
+    return () => {
+      // "Change" 이벤트 핸들러 제거
+      mediaQuery.removeEventListener("change", handleMediaChage);
+    };
+  }, [query]);
+
+  return media;
+}


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### PR 생성 날짜

- 2024/01/31

### 반영 브랜치

- feature/media-hooks -> develop

### PR 목적

- React에서는 브라우저의 화면 폭에 따라 반응하는 CSS의 미디어 쿼리(`@media`) 를 사용하기도 하지만,
- `디바이스` 자체의 화면폭을 확인하여 조작할 수 있는 전용 훅을 사용할 수 있습니다.
- 대표적으로 `react-responsive` 와 같은 전용 훅을 통해 모바일, 테블릿, 데스크탑 등을 구분하여 반응형에 대응할 수 있습니다.
- 하지만, 이러한 기능만을 위해 라이브러리를 설치하는 것보다 직접 커스텀으로 구현하는 것이 낫다고 판단하여 만들게 되었습니다.

### PR 내용

- 창의 사이즈를 추적하여 화면의 크기에 맞게 대응할 수 있도록 구현


### 사용 방법
```ts

function App() {
  const isDesktopOrLaptop = useMediaQuery({ query: "(min-width: 1224px)");
  const isBigScreen = useMediaQuery( "(min-width: 1824px)");
  const isTabletOrMobile = useMediaQuery( "(max-width: 1224px)" );
  const isPortrait = useMediaQuery( "(orientation: portrait)" );
  const isRetina = useMediaQuery( "(min-resolution: 2dppx)" );

  return (...);
}
```