### PR TITLE
첫 번째 랜더링을 확인할 수 있는 훅 기능 추가

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,3 +12,4 @@ export { default as useTimer } from "./src/hooks/useTimer";
 export { default as useLocalStorage } from "./src/hooks/useLocalStorage";
 export { default as useMediaQuery } from "./src/hooks/useMediaQuery";
 export { default as useCounter } from "./src/hooks/useCounter";
+export { default as useIsFirstRender } from "./src/hooks/useIsFirstRender";

--- a/src/hooks/useIsFirstRender.ts
+++ b/src/hooks/useIsFirstRender.ts
@@ -1,0 +1,31 @@
+import { useRef } from "react";
+
+/**
+ * 컴포넌트의 처음 랜더링 여부를 나타내기 위한 커스텀 훅입니다.
+ *
+ * 1. 첫 마운트시 (isFirstMount.current === true)
+ * isFirstMount는 useRef를 통해 생성된 객체로 초깃값이 true
+ * 함수가 처음 호출 시 isFirstMount.current가 true 이므로, 조건문이 실행
+ * isFirstMount.current를 false로 변경하고 true로 반환
+ *
+ * 2. 이후 랜더링 때 (isFirstMount.current === false)
+ * isFirstMount.current가 이전에 false로 변경이 되었기 때문에, 조건문이 실행되지 않음
+ * 즉, isFirstMount.current의 현재값인 false가 반환이됨.
+ *
+ * 특정 코드 블록을 실행하고 처음 랜더링떄만 부수 작업할 수 있는 효과를 줄 수 있다.
+ * @returns {boolean}
+ */
+export default function useIsFirstRender(): boolean {
+  // useRef를 사용하여 컴포넌트가 처음 렌더링되었는지 추적하는 ref 객체를 생성합니다.
+  const isFirstMount = useRef(true);
+
+  // 첫 번째 마운트시
+  if (isFirstMount.current) {
+    // isFirstMount를 false로 변경하고, true를 반환합니다.
+    isFirstMount.current = false;
+    return true;
+  }
+
+  // 현재 렌더링이 처음이 아니면 false를 반환합니다.
+  return isFirstMount.current;
+}


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### PR 생성 날짜

- 2024/02/02

### 반영 브랜치

- feature/side-effect-hooks -> develop

### PR 목적

- 첫 번째 랜더링시에만 특정 코드 블록을 형성하고자 할 떄 사용할 수 있는 훅이 필요할 때가 있다.
- 이러한 경우를 위해 첫 번째 랜더링에만 `true` 를 반환하고 그 이후에는 `false`를 반환하여 조건을 처리할 수 있다.

### PR 내용

- 컴포넌트가 첫 번째 마운트시 확인할 수 있는 기능의 훅 추가

### 사용 예시

```ts

return (
      <p>Is first render: {isFirst ? 'yes' : 'no'}</p>
)

```